### PR TITLE
feat(gpt): add gpt-4o model

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,15 @@ const AI_MODELS: Record<
     order?: number;
   }
 > = {
+  "gpt-4o": {
+    encoding: "cl100k_base",
+    prices: {
+      prompt: 0.005,
+      completion: 0.015,
+    },
+    maxTokens: 128000,
+    llm: ["OpenAI Chat (Langchain)"],
+  },
   "gpt-4": {
     encoding: "cl100k_base",
     prices: {


### PR DESCRIPTION
Pricing was halved that of preview based on: https://openai.com/api/pricing/

Max tokens was grabbed from: https://platform.openai.com/docs/models/gpt-4o